### PR TITLE
fix: added textencoding polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "axios": "^1.1.3",
+    "fast-text-encoding": "^1.0.6",
     "qrcode": "^1.5.1"
   },
   "devDependencies": {

--- a/src/crc.ts
+++ b/src/crc.ts
@@ -1,3 +1,4 @@
+import 'fast-text-encoding';
 import numToHex from './utils/numToHex';
 
 const crcTable = [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2124,6 +2124,11 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fast-text-encoding@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz#0aa25f7f638222e3396d72bf936afcf1d42d6867"
+  integrity sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w==
+
 fastest-levenshtein@^1.0.12:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz#9990f7d3a88cc5a9ffd1f1745745251700d497e2"


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

- **What is the current behavior?** (You can also link to an open issue here)

On React-Native, `TextEncoding` is not supported, so it throws an error when we try to use latest version.

- **What is the new behavior?**

Added `fast-text-encoding` polyfill.
