### PR TITLE
fix: export pixDynamicPayload types and update PIXRecPayload structure

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,3 +12,4 @@ export {
 } from './validate';
 export { PixError } from './types/pixError';
 export * from './types/pixElements';
+export * from './types/pixDynamicPayload';

--- a/src/types/pixDynamicPayload.ts
+++ b/src/types/pixDynamicPayload.ts
@@ -145,7 +145,7 @@ export type PIXRecPayload = {
     readonly periodicidade: Periodicidade;
   };
   readonly valor?: {
-    readonly valorRec: string;
+    readonly valorRec?: string;
     readonly valorMinimoRecebedor?: string;
   };
   readonly recebedor: {

--- a/tests/extractor.test.ts
+++ b/tests/extractor.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { parsePix, PixElementType } from '../src';
-import {
-  hasError,
-  isDynamicPix,
-  isRecurrencePix,
-  isStaticPix,
-} from '../src/validate';
+import { hasError, isDynamicPix, isStaticPix } from '../src/validate';
 import {
   RECURRENCE_DYNAMIC_UNRESERVED_EMV,
   DYNAMIC_TEST_EMV,


### PR DESCRIPTION
# Export PIX Dynamic Payload Types and Update PIXRecPayload Structure

## Changes
- Added export of `pixDynamicPayload` types in `src/index.ts`
- Updated `PIXRecPayload` structure in `src/types/pixDynamicPayload.ts`:
  - Made `valorRec` field optional in the `valor` object

## Description
This PR addresses the need to expose the Pix dynamic payload types to consumers of the library and improves the type structure for recurring PIX payments by making the `valorRec` field optional, allowing for more flexible payment configurations.

## Technical Details
- Added `export * from './types/pixDynamicPayload';` to `src/index.ts`
- Modified `PIXRecPayload` type to make `valorRec` optional: `readonly valorRec?: string`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded the public API to include additional types related to dynamic payloads.

- **Bug Fixes**
  - Made a property in the dynamic payload type optional, allowing for more flexible usage.

- **Chores**
  - Updated test imports to remove unused items, with no impact on test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->