### PR TITLE
fix: make objeto property optional in PIXRecPayload type

### DIFF
--- a/src/types/pixDynamicPayload.ts
+++ b/src/types/pixDynamicPayload.ts
@@ -135,7 +135,7 @@ export type PIXInstantPayload = {
 export type PIXRecPayload = {
   readonly idRec: string;
   readonly vinculo: {
-    readonly objeto: string;
+    readonly objeto?: string;
     readonly devedor: Devedor;
     readonly contrato: string;
   };


### PR DESCRIPTION
## **What kind of change does this PR introduce?**
**Bug fix** - This is a bug fix that addresses a type definition issue.

## **What is the current behavior?**
Before this change, the `objeto` property in the `PIXRecPayload` type was **required** (line 138 in the `vinculo` object). This means that when creating or working with PIX recurrence payloads, developers were forced to always provide the `objeto` field, even when it might not be necessary or available in certain scenarios.

## **What is the new behavior (if this is a feature change)?**
The `objeto` property is now **optional** (marked with `?`). This allows developers to create `PIXRecPayload` objects without necessarily providing the `objeto` field, making the type definition more flexible and aligned with real-world usage scenarios where this field might not always be required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Relaxed the requirement for the vinculo.objeto field in PIX receive payloads; it is now optional. This prevents unnecessary validation/type errors when the field is absent in real-world responses and reduces integration friction.

* **Refactor**
  * Updated type definitions to reflect the optional nature of vinculo.objeto in PIX dynamic payloads, improving alignment with upstream data and enhancing developer experience without impacting existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->